### PR TITLE
agregar logica jwt

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -1,0 +1,12 @@
+const jwt = require("jsonwebtoken");
+require("dotenv").config();
+//generate token
+const generateToken = (user) => {
+  user = {
+    username: user.username,
+    password: user.password,
+  };
+  return (token = jwt.sign(user, process.env.SECRET));
+};
+
+module.exports = { generateToken };


### PR DESCRIPTION
Juampi como estas?tuve que hacer esta nueva rama para agregar logica jwt,ya que la rama que corregiste estaba creada sobre el repo original de alkemy por que habia creado esa rama sin haber hecho un fork antes y por eso esa rama no existia en mi propio repo,es solo la generacion del token