### PR TITLE
#OT140-99 Test: Endpoints /activities

### DIFF
--- a/cypress/integration/test/activities.spec.js
+++ b/cypress/integration/test/activities.spec.js
@@ -14,7 +14,7 @@ describe('Endpoint /activities', () => {
             .should((response) => {
                 expect('Content-Type', /json/)
                 expect(response.status).to.eq(200)
-                expect(response.body).to.not.be.null
+                expect(response.body).to.deep.equal(response.body)
             });
     });
 
@@ -22,7 +22,7 @@ describe('Endpoint /activities', () => {
         cy.request(`${url}/${id}`)
             .should((response) => {
                 expect(response.status).to.eq(201)
-                expect(response.body).to.not.be.null
+                expect(response.body).to.deep.equal(response.body)
                 expect(response.body).to.have.property('data')
                 expect(response.body).to.have.property('message')
             });
@@ -45,7 +45,7 @@ describe('Endpoint /activities', () => {
                 body: activity
             }).should((response) => {
                 expect(response.status).to.eq(200)
-                expect(response.body).to.not.be.null
+                expect(response.body).to.deep.equal(response.body)
             })
             .its('body')
     });
@@ -58,7 +58,7 @@ describe('Endpoint /activities', () => {
             })
             .should((response) => {
                 expect(response.status).to.eq(201)
-                expect(response.body).to.not.be.null
+                expect(response.body).to.deep.equal(response.body)
             });
     });
 
@@ -82,7 +82,7 @@ describe('Endpoint /activities', () => {
             })
             .should((response) => {
                 expect(response.status).to.eq(200)
-                expect(response.body).to.not.be.null
+                expect(response.body).to.deep.equal(response.body)
                 expect(response.body).to.have.property('message')
             });
     });

--- a/cypress/integration/test/activities.spec.js
+++ b/cypress/integration/test/activities.spec.js
@@ -1,0 +1,101 @@
+const url = 'http://localhost:3000/activities';
+const id = 1;
+const noId = 99999;
+
+const activity = {
+    name: 'TEST Name',
+    content: 'TEST Content'
+}
+
+describe('Endpoint /activities', () => {
+
+    it('Get all activities', () => {
+        cy.request('GET', url)
+            .should((response) => {
+                expect('Content-Type', /json/)
+                expect(response.status).to.eq(200)
+                expect(response.body).to.not.be.null
+            });
+    });
+
+    it('Get an activity by Id', () => {
+        cy.request(`${url}/${id}`)
+            .should((response) => {
+                expect(response.status).to.eq(201)
+                expect(response.body).to.not.be.null
+                expect(response.body).to.have.property('data')
+                expect(response.body).to.have.property('message')
+            });
+    });
+
+    it('Get an activity by wrong Id', () => {
+        cy.request({
+            url: `${url}/${noId}`,
+            failOnStatusCode: false
+        }).should((response) => {
+            expect(response.status).to.eq(404)
+            expect(response.body).to.not.be.null
+        });
+    });
+
+    it('Post a new activity', () => {
+        cy.request({
+                method: 'POST',
+                url,
+                body: activity
+            }).should((response) => {
+                expect(response.status).to.eq(200)
+                expect(response.body).to.not.be.null
+            })
+            .its('body')
+    });
+
+    it('Update an activity by Id', () => {
+        cy.request({
+                method: 'PUT',
+                url: `${url}/${id}`,
+                body: activity
+            })
+            .should((response) => {
+                expect(response.status).to.eq(201)
+                expect(response.body).to.not.be.null
+            });
+    });
+
+    it('Update an activity by wrong Id', () => {
+        cy.request({
+                method: 'PUT',
+                url: `${url}/${noId}`,
+                body: activity,
+                failOnStatusCode: false
+            })
+            .should((response) => {
+                expect(response.status).to.eq(404)
+                expect(response.body).to.not.be.null
+            });
+    });
+
+    it('Delete an activity by Id', () => {
+        cy.request({
+                method: 'DELETE',
+                url: `${url}/${id}`,
+            })
+            .should((response) => {
+                expect(response.status).to.eq(200)
+                expect(response.body).to.not.be.null
+                expect(response.body).to.have.property('message')
+            });
+    });
+
+    it('Delete an activity by wrong Id', () => {
+        cy.request({
+                method: 'DELETE',
+                url: `${url}/${noId}`,
+                failOnStatusCode: false
+            })
+            .should((response) => {
+                expect(response.status).to.eq(404)
+                expect(response.body).to.not.be.null
+            });
+    });
+});

--- a/cypress/integration/test/activities.spec.js
+++ b/cypress/integration/test/activities.spec.js
@@ -14,7 +14,7 @@ describe('Endpoint /activities', () => {
             .should((response) => {
                 expect('Content-Type', /json/)
                 expect(response.status).to.eq(200)
-                expect(response.body).to.deep.equal(response.body)
+                expect(response.body).to.have.property('data')
             });
     });
 
@@ -34,7 +34,7 @@ describe('Endpoint /activities', () => {
             failOnStatusCode: false
         }).should((response) => {
             expect(response.status).to.eq(404)
-            expect(response.body).to.not.be.null
+            expect(response.body).to.eq(`The activity with id ${noId} doesn't exist.`)
         });
     });
 
@@ -45,7 +45,7 @@ describe('Endpoint /activities', () => {
                 body: activity
             }).should((response) => {
                 expect(response.status).to.eq(200)
-                expect(response.body).to.deep.equal(response.body)
+                expect(response.body).to.deep.equal('data', 'message')
             })
             .its('body')
     });
@@ -58,7 +58,7 @@ describe('Endpoint /activities', () => {
             })
             .should((response) => {
                 expect(response.status).to.eq(201)
-                expect(response.body).to.deep.equal(response.body)
+                expect(response.body).to.deep.equal('data')
             });
     });
 
@@ -71,7 +71,7 @@ describe('Endpoint /activities', () => {
             })
             .should((response) => {
                 expect(response.status).to.eq(404)
-                expect(response.body).to.not.be.null
+                expect(response.body).to.eq(`The activity with the id ${noId} doesn't exist.`)
             });
     });
 
@@ -82,7 +82,7 @@ describe('Endpoint /activities', () => {
             })
             .should((response) => {
                 expect(response.status).to.eq(200)
-                expect(response.body).to.deep.equal(response.body)
+                expect(response.body).to.eq(`Activity with id ${id} has been deleted.`)
                 expect(response.body).to.have.property('message')
             });
     });
@@ -95,7 +95,7 @@ describe('Endpoint /activities', () => {
             })
             .should((response) => {
                 expect(response.status).to.eq(404)
-                expect(response.body).to.not.be.null
+                expect(response.body).to.eq(`Activity with id ${noId} doesn't exist.`)
             });
     });
 });


### PR DESCRIPTION
**#OT140-99**
**Test: Endpoints /activities**

- Se crearon los test contemplando casos de éxito y errores (como ingresar ID incorrecto).

Documentación de los endpoints con Postman:
https://documenter.getpostman.com/view/17183774/UVkqsvMA

![image](https://user-images.githubusercontent.com/78069468/165359876-f677ea8e-8459-4c08-beee-ac2f08bb46f1.png)

![image](https://user-images.githubusercontent.com/78069468/165359934-05928e72-2cbc-4cbf-83ba-6957e64d3c38.png)

![image](https://user-images.githubusercontent.com/78069468/165359969-da3efdfa-0b18-41b3-a4c1-3e3375be3d1c.png)
